### PR TITLE
Improve `useBalance` and `useAccount`

### DIFF
--- a/src/hooks/useBalance.tsx
+++ b/src/hooks/useBalance.tsx
@@ -2,7 +2,7 @@ import { Balance } from '@alephium/web3/dist/src/api/api-alephium';
 import { useEffect, useState } from 'react';
 import { useContext } from '../components/AlephiumConnect';
 
-export function useBalance() {
+export function useBalance<T>(value?: T) {
   const context = useContext()
   const [balance, setBalance] = useState<Balance>()
 
@@ -16,7 +16,7 @@ export function useBalance() {
     }
 
     handler()
-  }, [context.signerProvider?.nodeProvider, context.account])
+  }, [context.signerProvider?.nodeProvider, context.account, value])
 
   return { balance }
 }


### PR DESCRIPTION
1. `useBalance` only retrieves the balance when the wallet is reconnected. Sometimes we need to retrieve the balance again when a transaction is completed or the block height is updated. So I added an additional parameter to trigger the retrieval of balance.

2. `useAccount` will update the account once again when the wallet is already connected. This will result in two consecutive requests for balance when `useAccount` and `useBalance` are used together, and the second request is unnecessary.